### PR TITLE
Add Cav vs Pike tip to AP planner

### DIFF
--- a/kg2bot.py
+++ b/kg2bot.py
@@ -788,6 +788,10 @@ async def ap(ctx: commands.Context, *, args: str):
             if troops:
                 break
 
+    # Always include Cav vs Pike tip
+    tip = cav_needed_vs_pike(troops, hits)
+    embed.add_field(name="🐎 Cav vs Pike", value=tip, inline=False)
+
     try:
         ts = datetime.fromisoformat(row["captured_at"]).strftime("%Y-%m-%d %H:%M")
     except Exception:


### PR DESCRIPTION
## Summary
- Always include a Cav vs Pike tip in the AP planner embed

## Testing
- `RUN_TESTS=1 python kg2bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6006f4e348333842de157cffa584d